### PR TITLE
dart: null safety upgrade

### DIFF
--- a/example/example-types.dart
+++ b/example/example-types.dart
@@ -1,7 +1,7 @@
 import 'package:vnum/vnum.dart';
 
 @VnumDefinition
-class CarType extends Vnum<String> {
+class CarType extends Vnum<String?> {
   static const CarType sedan = const CarType.define("sedan-value");
   static const CarType suv = const CarType.define("suv-value");
   static const CarType truck = const CarType.define("truck-value");
@@ -9,7 +9,7 @@ class CarType extends Vnum<String> {
 
   /// Constructors
   const CarType.define(String fromValue) : super.define(fromValue);
-  factory CarType(String value) => Vnum.fromValue(value,CarType);
+  factory CarType(String? value) => Vnum.fromValue(value,CarType) as CarType;
 
   /// Support for Json Serialization
   dynamic toJson() => this.value;
@@ -23,7 +23,7 @@ class Fruit extends Vnum<int> {
   static const Fruit banana = const Fruit.define(3);
   
   const Fruit.define(int fromValue) : super.define(fromValue);
-  factory Fruit(int value) => Vnum.fromValue(value,Fruit);
+  factory Fruit(int value) => Vnum.fromValue(value,Fruit) as Fruit;
 
   String color(){
     if (value == Fruit.apple.value) {

--- a/example/example.dart
+++ b/example/example.dart
@@ -64,7 +64,7 @@ void serializationExample() {
 class SampleResponse {
   
   @JsonKey(name: "carType")
-  CarType carType;
+  CarType? carType;
 
   SampleResponse();
   factory SampleResponse.fromJson(Map<String, dynamic> json) =>

--- a/lib/vnum.dart
+++ b/lib/vnum.dart
@@ -16,7 +16,7 @@ const VnumDefinition = const VnumTypeReflectable();
 @VnumDefinition
 @JsonSerializable()
 abstract class Vnum<T> {
-  final T value;
+  final T? value;
   const Vnum() : value = null;
 
   /// Returns an instance of Vnum with the provided value
@@ -43,7 +43,7 @@ abstract class Vnum<T> {
   /// Find value through reflection, in case of no item, will return null
   static dynamic _fetchValue(dynamic rawValue, dynamic baseType) {
     //Mirror the base type
-    ClassMirror aMirror = VnumDefinition.reflectType(baseType);
+    ClassMirror aMirror = VnumDefinition.reflectType(baseType) as ClassMirror;
 
     /// Get declerations
     final declarations = aMirror.declarations;
@@ -58,14 +58,14 @@ abstract class Vnum<T> {
         continue;
       }
 
-      var value = parameterValue as VariableMirror;
+      var value = parameterValue;
 
       /// Ignore the property is not declared as static const
       if (!value.isStatic || !value.isConst) {
         continue;
       }
       var staticParam = aMirror.invokeGetter(value.simpleName);
-      var enumLoaded = staticParam as Vnum;
+      var enumLoaded = staticParam as Vnum?;
 
       /// Return if any property has a same value provided
       if (enumLoaded != null && enumLoaded.value == rawValue) {
@@ -79,7 +79,7 @@ abstract class Vnum<T> {
  static List<Vnum>  allCasesFor(dynamic object ) {
     List<Vnum> _result = [];
     //Mirror the base type
-    ClassMirror aMirror = VnumDefinition.reflectType(object);
+    ClassMirror aMirror = VnumDefinition.reflectType(object) as ClassMirror;
 
     /// Get declerations
     final declarations = aMirror.declarations;
@@ -94,14 +94,14 @@ abstract class Vnum<T> {
         continue;
       }
 
-      var value = parameterValue as VariableMirror;
+      var value = parameterValue;
 
       /// Ignore the property is not declared as static const
       if (!value.isStatic || !value.isConst) {
         continue;
       }
       var staticParam = aMirror.invokeGetter(value.simpleName);
-      var enumLoaded = staticParam as Vnum;
+      var enumLoaded = staticParam as Vnum?;
       if (enumLoaded != null) {
         _result.add(enumLoaded);
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,161 +7,182 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "22.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.4"
-  archive:
-    dependency: transitive
-    description:
-      name: archive
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.13"
+    version: "1.7.1"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "2.1.1"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   build:
     dependency: transitive
     description:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "2.0.2"
   build_config:
     dependency: transitive
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.1+1"
+    version: "1.0.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.3"
+    version: "2.0.3"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.2"
+    version: "2.0.5"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "7.0.0"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "5.1.0"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.4.0"
+    version: "8.1.0"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.1"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.1"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.6"
+    version: "3.0.1"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.3"
+    version: "2.0.1"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.2"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.9"
+    version: "1.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -172,209 +193,160 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.1"
   graphs:
     dependency: transitive
     description:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.0"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.12.0+2"
+    version: "2.0.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.3"
-  image:
-    dependency: transitive
-    description:
-      name: image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.12"
+    version: "4.0.0"
   io:
     dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.3"
+    version: "1.0.0"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1+1"
+    version: "0.6.3"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "4.0.1"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.0"
+    version: "4.1.3"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+2"
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.6+2"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.3"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
+    version: "1.0.0"
   package_config:
     dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
-  package_resolver:
-    dependency: transitive
-    description:
-      name: package_resolver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.10"
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4"
+    version: "1.8.0"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0+1"
-  petitparser:
-    dependency: transitive
-    description:
-      name: petitparser
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.4.0"
+    version: "1.11.1"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.2"
+    version: "2.0.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
+    version: "1.0.0"
   reflectable:
     dependency: "direct main"
     description:
       name: reflectable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.4"
+    version: "3.0.2"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.5"
+    version: "1.1.4"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2+5"
+    version: "1.0.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -386,104 +358,97 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.5"
+    version: "1.0.2"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.16+1"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.3.0"
   timing:
     dependency: transitive
     description:
       name: timing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1+2"
+    version: "1.0.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+10"
+    version: "1.0.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.12"
-  xml:
-    dependency: transitive
-    description:
-      name: xml
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.6.1"
+    version: "2.1.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.15"
+    version: "3.1.0"
 sdks:
-  dart: ">=2.7.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,19 +4,19 @@ version: 1.2.6
 homepage: https://github.com/AmirKamali/Flutter_Vnum
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  reflectable: ^2.2.4
-  json_annotation: ^3.0.1
+  reflectable: ^3.0.2
+  json_annotation: ^4.0.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  build_runner: any
-  json_serializable: any
+  build_runner: ^2.0.5
+  json_serializable: ^4.1.3
   
 
   

--- a/test/sample_response.dart
+++ b/test/sample_response.dart
@@ -8,7 +8,7 @@ part 'sample_response.g.dart';
 class SampleResponse {
   
   @JsonKey(name: "carType")
-  CarType carType;
+  CarType? carType;
 
   SampleResponse();
   factory SampleResponse.fromJson(Map<String, dynamic> json) =>

--- a/test/test_types.dart
+++ b/test/test_types.dart
@@ -1,7 +1,7 @@
 import 'package:vnum/vnum.dart';
 
 @VnumDefinition
-class CarType extends Vnum<String> {
+class CarType extends Vnum<String?> {
   static const CarType sedan = const CarType.define("sedan-value");
   static const CarType suv = const CarType.define("suv-value");
   static const CarType truck = const CarType.define("truck-value");
@@ -9,7 +9,7 @@ class CarType extends Vnum<String> {
 
   /// Constructors
   const CarType.define(String fromValue) : super.define(fromValue);
-  factory CarType(String value) => Vnum.fromValue(value,CarType);
+  factory CarType(String? value) => Vnum.fromValue(value,CarType) as CarType;
 
   /// Json
   dynamic toJson() => this.value;

--- a/test/vnum_test.reflectable.dart
+++ b/test/vnum_test.reflectable.dart
@@ -87,13 +87,13 @@ final _data = <r.Reflectable, r.ReflectorData>{
         new r.MethodMirrorImpl(r"toJson", 65538, 0, null, null, null, null,
             const <int>[], const prefix0.VnumTypeReflectable(), null),
         new r.ImplicitGetterMirrorImpl(
-            const prefix0.VnumTypeReflectable(), 0, 0, 0, 6),
+            const prefix0.VnumTypeReflectable(), 0, 0),
         new r.ImplicitGetterMirrorImpl(
-            const prefix0.VnumTypeReflectable(), 1, 0, 0, 7),
+            const prefix0.VnumTypeReflectable(), 1, 0),
         new r.ImplicitGetterMirrorImpl(
-            const prefix0.VnumTypeReflectable(), 2, 0, 0, 8),
+            const prefix0.VnumTypeReflectable(), 2, 0),
         new r.ImplicitGetterMirrorImpl(
-            const prefix0.VnumTypeReflectable(), 3, 0, 0, 9),
+            const prefix0.VnumTypeReflectable(), 3, 0),
         new r.MethodMirrorImpl(r"define", 128, 0, -1, 0, 0, null,
             const <int>[0], const prefix0.VnumTypeReflectable(), null),
         new r.MethodMirrorImpl(r"", 1, 0, -1, 0, 0, null, const <int>[1],
@@ -111,7 +111,7 @@ final _data = <r.Reflectable, r.ReflectorData>{
         new r.MethodMirrorImpl(r"runtimeType", 131075, null, -1, 5, 5, null,
             const <int>[], const prefix0.VnumTypeReflectable(), null),
         new r.ImplicitGetterMirrorImpl(
-            const prefix0.VnumTypeReflectable(), 4, -1, -1, 18),
+            const prefix0.VnumTypeReflectable(), 4, -1),
         new r.MethodMirrorImpl(r"allCasesFor", 4325394, 1, -1, 6, 7, null,
             const <int>[5], const prefix0.VnumTypeReflectable(), null),
         new r.MethodMirrorImpl(r"toJson", 65538, 1, null, null, null, null,
@@ -274,7 +274,7 @@ final _data = <r.Reflectable, r.ReflectorData>{
       [])
 };
 
-final _memberSymbolMap = null;
+final dynamic _memberSymbolMap = null;
 
 initializeReflectable() {
   r.data = _data;


### PR DESCRIPTION
This is more of an RFC. The tests aren't passing yet. Hopefully this PR can serve as a useful template for the eventual fix.

Steps followed:

dart pub upgrade --null-safety
dart pub outdated --mode=null-safety
dart pub get
dart pub upgrade --null-safety
dart migrate
dart migrate --skip-import-check
vi test/vnum_test.reflectable.dart
flutter test

There are a few test failures due to null safety

Related to: https://github.com/AmirKamali/Flutter_Vnum/issues/10